### PR TITLE
opt-in to MTE async mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
     <!-- Empty task affinity is used to prevent task hijacking -->
     <application
         android:name=".App"
+        android:memtagMode="async"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
currently only benefits GrapheneOS users on Pixel 8 and 9 who don't turn on MTE for all apps or Molly manually. hopefully will be extended to all Pixel users and then more devices